### PR TITLE
Update Getting Started to use ibm-granite model (8b-128k) on Replicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 venv
 .venv
+.venv*
 .env
 .ipynb_checkpoints
+.vscode

--- a/recipes/Getting_Started_with_Granite_Code.ipynb
+++ b/recipes/Getting_Started_with_Granite_Code.ipynb
@@ -10,38 +10,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00a45854-f221-466b-a0b4-78effeae9f41",
-   "metadata": {},
-   "source": [
-    "## Introduction\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fe10934b-14de-4b36-a251-1178a3ada873",
-   "metadata": {},
-   "source": [
-    "## Using a local model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f29cf3fd-50b0-45d6-8588-a6ffc3d51da9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cfc017ba-fe00-43a4-9299-d4610946076d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
    "id": "2a3c0dce-3630-4408-bd51-23db676874cf",
    "metadata": {},
    "source": [
@@ -59,18 +27,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "dc5fa737-fbd4-422e-bed5-efae32e8c736",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import getpass, os\n",
     "\n",
@@ -91,14 +51,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 16,
    "id": "2eeb4c2e-ec15-4b73-8229-35dae503115c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "deployment_id = \"ibm/granite-dev\"\n",
-    "\n",
-    "# model_id = \"ibm/granite-8b-code-instruct:50da94a0b1b5d28e3161d1312077d856eb673b87e633438362e4820fed563444\""
+    "model_id = \"ibm-granite/granite-8b-code-instruct-128k\""
    ]
   },
   {
@@ -111,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 3,
    "id": "02f99de7-ff2e-4ae4-b1f2-1ac4453b4c19",
    "metadata": {},
    "outputs": [],
@@ -129,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "4dcdf174-6f25-432c-b2d6-6370f4eff98b",
    "metadata": {
     "collapsed": true,
@@ -138,39 +96,14 @@
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting replicate\n",
-      "  Downloading replicate-0.30.1-py3-none-any.whl (42 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.9/42.9 kB\u001b[0m \u001b[31m690.4 kB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: httpx<1,>=0.21.0 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (0.27.0)\n",
-      "Requirement already satisfied: packaging in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (23.2)\n",
-      "Requirement already satisfied: pydantic>1.10.7 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (2.7.1)\n",
-      "Requirement already satisfied: typing-extensions>=4.5.0 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (4.8.0)\n",
-      "Requirement already satisfied: anyio in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (4.0.0)\n",
-      "Requirement already satisfied: certifi in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (2023.5.7)\n",
-      "Requirement already satisfied: httpcore==1.* in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (1.0.5)\n",
-      "Requirement already satisfied: idna in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (3.4)\n",
-      "Requirement already satisfied: sniffio in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (1.3.0)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.21.0->replicate) (0.14.0)\n",
-      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from pydantic>1.10.7->replicate) (0.6.0)\n",
-      "Requirement already satisfied: pydantic-core==2.18.2 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from pydantic>1.10.7->replicate) (2.18.2)\n",
-      "Installing collected packages: replicate\n",
-      "Successfully installed replicate-0.30.1\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pip install replicate"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "id": "65423430-1e61-4ed8-8396-3f96860463fe",
    "metadata": {},
    "outputs": [],
@@ -179,8 +112,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "238f7668",
+   "metadata": {},
+   "source": [
+    "### Pass the prompt to the model for completion"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "id": "736d4153-3900-473c-a46b-d5e326dfb929",
    "metadata": {},
    "outputs": [
@@ -188,14 +129,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['System:\\nYou are a helpful assistant\\n\\nQuestion:\\ndef f(x):\\n\\nAnswer:\\ndef f(x):\\n    return x*x<|endoftext|>']\n"
+      "['def', ' f', '(', 'x', '):', '\\n', '']\n"
      ]
     }
    ],
    "source": [
-    "deployment = replicate.deployments.get(deployment_id)\n",
+    "model = replicate.models.get(model_id)\n",
+    "version = model.versions.get(\"797c070dc871d8fca417d7d188cf050778d7ce21a0318d26711a54207e9ee698\")\n",
     "\n",
-    "prediction = deployment.predictions.create(\n",
+    "prediction = replicate.predictions.create(\n",
+    "  version=version,\n",
     "  input={\"prompt\": prompt}\n",
     ")\n",
     "\n",
@@ -203,40 +146,6 @@
     "\n",
     "print(prediction.output)\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8f6b04ff-1750-425f-a677-ac31715b4388",
-   "metadata": {},
-   "source": [
-    "### Using Granite Code hosted on Replicate from LangChain"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "246b83c6-a7fc-4e83-a000-4f18c9d42f1f",
-   "metadata": {},
-   "source": [
-    "See https://python.langchain.com/v0.2/docs/integrations/providers/replicate/"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "94f036ed-f12c-4409-b474-a8ef5ce6e8c2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = Replicate(model=model_id)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13445753-e887-4146-a732-0685046e9cec",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -255,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Tidy up the Getting Started recipe:

- Remove empty/broken sections (Local models, Langchain).
- Update the model to use `ibm-granite/granite-8b-code-instruct-128k` on replicate.
- Update the prompt section to use `model` instead of `deployment`.
- Test (it works).