### PR TITLE
Some notebook refinements

### DIFF
--- a/recipes/Getting_Started_with_Granite_Code.ipynb
+++ b/recipes/Getting_Started_with_Granite_Code.ipynb
@@ -21,24 +21,10 @@
    "id": "fe10934b-14de-4b36-a251-1178a3ada873",
    "metadata": {},
    "source": [
-    "## Using a local model"
+    "## Using a hosted vs. a local model\n",
+    "\n",
+    "This notebook demonstrates using inference calls against a model hosted on [Replicate](https://replicate.com/). To see how you can use [Ollama](https://ollama.com/) to host models locally instead, see the [Continue VSCode](Continue_VSCode/Continue_VSCode.ipynb) recipe."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f29cf3fd-50b0-45d6-8588-a6ffc3d51da9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cfc017ba-fe00-43a4-9299-d4610946076d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -59,18 +45,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "dc5fa737-fbd4-422e-bed5-efae32e8c736",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      " ········\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import getpass, os\n",
     "\n",
@@ -91,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "2eeb4c2e-ec15-4b73-8229-35dae503115c",
    "metadata": {},
    "outputs": [],
@@ -111,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "02f99de7-ff2e-4ae4-b1f2-1ac4453b4c19",
    "metadata": {},
    "outputs": [],
@@ -129,48 +107,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "4dcdf174-6f25-432c-b2d6-6370f4eff98b",
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting replicate\n",
-      "  Downloading replicate-0.30.1-py3-none-any.whl (42 kB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m42.9/42.9 kB\u001b[0m \u001b[31m690.4 kB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m \u001b[36m0:00:01\u001b[0m\n",
-      "\u001b[?25hRequirement already satisfied: httpx<1,>=0.21.0 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (0.27.0)\n",
-      "Requirement already satisfied: packaging in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (23.2)\n",
-      "Requirement already satisfied: pydantic>1.10.7 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (2.7.1)\n",
-      "Requirement already satisfied: typing-extensions>=4.5.0 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from replicate) (4.8.0)\n",
-      "Requirement already satisfied: anyio in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (4.0.0)\n",
-      "Requirement already satisfied: certifi in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (2023.5.7)\n",
-      "Requirement already satisfied: httpcore==1.* in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (1.0.5)\n",
-      "Requirement already satisfied: idna in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (3.4)\n",
-      "Requirement already satisfied: sniffio in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpx<1,>=0.21.0->replicate) (1.3.0)\n",
-      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.21.0->replicate) (0.14.0)\n",
-      "Requirement already satisfied: annotated-types>=0.4.0 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from pydantic>1.10.7->replicate) (0.6.0)\n",
-      "Requirement already satisfied: pydantic-core==2.18.2 in /Users/pingel/miniconda3/lib/python3.11/site-packages (from pydantic>1.10.7->replicate) (2.18.2)\n",
-      "Installing collected packages: replicate\n",
-      "Successfully installed replicate-0.30.1\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pip install replicate"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "65423430-1e61-4ed8-8396-3f96860463fe",
    "metadata": {},
    "outputs": [],
@@ -180,18 +129,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "736d4153-3900-473c-a46b-d5e326dfb929",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['System:\\nYou are a helpful assistant\\n\\nQuestion:\\ndef f(x):\\n\\nAnswer:\\ndef f(x):\\n    return x*x<|endoftext|>']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "deployment = replicate.deployments.get(deployment_id)\n",
     "\n",
@@ -227,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Replicate(model=model_id)"
+    "model = replicate.Replicate(model=model_id)"
    ]
   },
   {
@@ -255,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/recipes/Text_to_Shell/Text_to_Shell.ipynb
+++ b/recipes/Text_to_Shell/Text_to_Shell.ipynb
@@ -20,6 +20,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install ollama"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,35 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You can use the following bash script to achieve this. \n",
-      "\n",
-      "```bash\n",
-      "#!/bin/bash\n",
-      "\n",
-      "start_date=\"Jan 12, 2023\"\n",
-      "end_date=\"Jan 20, 2024\"\n",
-      "\n",
-      "start=$(date -d \"$start_date\" +%s)\n",
-      "end=$(date -d \"$end_date\" +%s)\n",
-      "\n",
-      "echo \"Number of days between the dates = $(($((end - start))/86400))\"\n",
-      "```\n",
-      "\n",
-      "In this script, we first define the start and end dates as variables. Then, we use the `date` command with the `-d` option to convert the date strings into UNIX timestamp format using the `+%s` flag. \n",
-      "\n",
-      "Next, we subtract the start timestamp from the end timestamp and divide the result by the number of seconds in a day (86400) to get the number of days between the dates. Finally, we use the `echo` command to display the result.\n",
-      "\n",
-      "Make sure to save the script with a `.sh` extension (e.g., `calculate_days.sh`), make it executable using the `chmod +x calculate_days.sh` command, and run it using `./calculate_days.sh`. The output will be the number of days between the specified dates.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import ollama\n",
     "\n",
@@ -76,6 +59,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you are running on a Mac, it is likely that the invocation of `date` will be incorrect for the MacOS version of this command. Try adding the following sentence to the prompt and see what happens: `Make sure the generated shell commands are MacOS-compatible.`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Few-shot Prompting with Granite Code 8b\n",
     "\n",
     "In few-shot prompting, you provide the model with a question and some examples. The model will generate an answer given its training. The additional examples help the model zero in on a pattern, which may be required for smaller models to perform well at this task."
@@ -83,21 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#!/bin/bash\n",
-      "start_date=$(date -d \"Jan 12, 2023\" +%s)\n",
-      "end_date=$(date -d \"Jan 20, 2024\" +%s)\n",
-      "diff=$(( $end_date - $start_date ))\n",
-      "echo \"$diff seconds = $(($diff/60/60/24)) days\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "examples = \"\"\"\n",
     "Question:\n",
@@ -151,24 +129,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#!/bin/bash\n",
-      "# Set start date as Jan 12, 2023\n",
-      "start_date=\"2023-01-12\"\n",
-      "# Set end date as Jan 20, 2024\n",
-      "end_date=\"2024-01-20\"\n",
-      "# Calculate the number of days using a one-liner\n",
-      "num_days=$(date -d \"$end_date\" +%s -date \"$start_date\" +%s | bc) / (60 * 60 * 24)\n",
-      "echo \"Number of days between $start_date and $end_date: $num_days\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "system_prompt = \"You are a helpful software engineer. You write clear, concise, well-commented code.\"\n",
     "\n",
@@ -184,11 +147,18 @@
     "])\n",
     "print(response['message']['content'])\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -202,9 +172,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/recipes/Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb
+++ b/recipes/Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb
@@ -22,6 +22,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install ollama"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ollama\n",
     "import os"
    ]
@@ -36,36 +45,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#!/bin/bash\n",
-      "for file in *; do\n",
-      "  if [ -f \"$file\" ]; then\n",
-      "    if [ $(wc -c < \"$file\") -gt 500 ]; then\n",
-      "      echo $file is over 500 bytes\n",
-      "    fi\n",
-      "  fi\n",
-      "done\n",
-      "LICENSE is over 500 bytes\n",
-      "README.md is over 500 bytes\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "examples = \"\"\"\n",
     "Question:\n",
@@ -99,7 +81,7 @@
     "\n",
     "user_prompt = examples + \"\\nQuestion:\\n\" + query + \"\\nAnswer:\\n\"\n",
     "\n",
-    "system_prompt = \"You are a helpful software engineer. You write clear, concise, well-commented code.\"\n",
+    "system_prompt = \"You are a helpful software engineer. You write clear, concise, well-commented code. You only print valid code, not any commentary about it nor markdown syntax to wrap the code.\"\n",
     "\n",
     "response = ollama.generate(\n",
     "  model='granite-code:20b',\n",
@@ -115,39 +97,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "If you are running on a Mac, it is possible that some of the generated shell commands will be incorrect for the MacOS version of them (e.g., this often happens with the `date` and `ps` commands). Try adding the following sentence to the `system_prompt` in the previous cell and see what happens: `Make sure the generated shell commands are MacOS-compatible.`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Let's try another one."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "#!/bin/bash\n",
-      "# Recursively find Jupyter notebooks in the current directory and print their paths\n",
-      "\n",
-      "find . -name '*.ipynb'\n",
-      "./recipes/Text_to_Shell/Text_to_Shell.ipynb\n",
-      "./recipes/Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "query = \"Write a bash script to recursively find Jupyter notebooks in the current directory and print their paths.\"\n",
+    "query = \"Write a bash script to recursively find Jupyter notebooks in the parent directory and print their paths.\"\n",
     "\n",
     "user_prompt = examples + \"\\nQuestion:\\n\" + query + \"\\nAnswer:\\n\"\n",
     "\n",
@@ -162,11 +128,18 @@
     "\n",
     "os.system(bash_code)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -180,9 +153,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
For those that use Ollama, added `!pip install ollama` cells.

For the text to shell notebooks, add tips about asking the prompts to generate MacOS-compatible output.

Clear the cell outputs, so the notebooks look cleaner when you start.