### PR TITLE
Fix links to Coding Assistant in VSCode

### DIFF
--- a/recipes/Getting_Started_with_Granite_Code.ipynb
+++ b/recipes/Getting_Started_with_Granite_Code.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "This notebook demonstrates using inference calls against a model hosted on [Replicate](https://replicate.com/). To see how you can use [Ollama](https://ollama.com/) to host models locally instead, see the [Continue VSCode](Continue_VSCode/Continue_VSCode.ipynb) recipe."
+    "This notebook demonstrates using inference calls against a model hosted on [Replicate](https://replicate.com/). To see how you can use [Ollama](https://ollama.com/) to host models locally instead, see the [Coding Assistant in VSCode](Coding_Assistant_in_VSCode/Coding_Assistant_in_VSCode.ipynb) recipe."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdin",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       " ········\n"
@@ -285,7 +285,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,21 +1,22 @@
 # Recipes
 
 ### Getting Started
-1. [Basic Inference](Getting_Started_with_Granite_Code.ipynb)
+1. [Running Jupyter Notebooks Locally](Getting_Started_with_Jupyter_Locally/Getting_Started_with_Jupyter_Locally.md)
+2. [Basic Inference](Getting_Started_with_Granite_Code.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-code-cookbook/blob/main/recipes/Getting_Started_with_Granite_Code.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
 
 ### IDE Assistants
-1. [Coding Assistant in VSCode](Coding_Assistant_in_VSCode/)
+1. [Coding Assistant in VSCode](Coding_Assistant_in_VSCode/Coding_Assistant_in_VSCode.ipynb)
 
 
 ### Generating Code
-1. [Text to Shell Script](Text_to_Shell/)
+1. [Text to Shell Script](Text_to_Shell/Text_to_Shell.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-code-cookbook/blob/main/recipes/Text_to_Shell/Text_to_Shell.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
-1. [Text to Shell Script with Execution](Text_to_Shell_Exec/)
+1. [Text to Shell Script with Execution](Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-code-cookbook/blob/main/recipes/Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -7,7 +7,7 @@
    </a>
 
 ### IDE Assistants
-1. [Assistant in VSCode Using Continue](Continue_VSCode/)
+1. [Coding Assistant in VSCode](Coding_Assistant_in_VSCode/)
 
 
 ### Generating Code


### PR DESCRIPTION
The Continue/VSCode recipe name has changed to "Coding Assistant in VSCode". This fixes the links in the receipe README and the Getting Started recipe.