### PR TITLE
Add WatsonX to Getting Started recipe

### DIFF
--- a/recipes/Getting_Started_with_Granite_Code.ipynb
+++ b/recipes/Getting_Started_with_Granite_Code.ipynb
@@ -206,8 +206,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model_id = \"granite-code:3b\"\n",
-    "model_id = \"granite-code:8b\"\n",
+    "model_id = \"granite-code:3b\"\n",
+    "# model_id = \"granite-code:8b\"\n",
     "# model_id = \"granite-code:20b\"\n",
     "\n",
     "model = find_langchain_model(platform=\"ollama\", model_id=model_id)"

--- a/recipes/Getting_Started_with_Granite_Code.ipynb
+++ b/recipes/Getting_Started_with_Granite_Code.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "83dfc528-7220-4c9f-ae67-07b3f37a46d6",
    "metadata": {},
    "outputs": [],
@@ -59,14 +59,14 @@
    "source": [
     "### Define a Prompt\n",
     "\n",
-    "The cells below demonstrate a remote option and a local option for model inference.\n",
+    "The sections below demonstrate remote options and a local option for model inference.\n",
     "\n",
-    "Both will perform a blocking call using the following prompt:"
+    "Each will perform a blocking call using the following prompt:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "02f99de7-ff2e-4ae4-b1f2-1ac4453b4c19",
    "metadata": {},
    "outputs": [],
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "2eeb4c2e-ec15-4b73-8229-35dae503115c",
    "metadata": {},
    "outputs": [],
@@ -144,7 +144,7 @@
     "model_id = \"ibm-granite/granite-8b-code-instruct-128k\"\n",
     "# model_id = \"ibm-granite/granite-20b-code-instruct-8k\"\n",
     "\n",
-    "granite_via_replicate = find_langchain_model(platform=\"Replicate\", model_id=model_id)"
+    "model = find_langchain_model(platform=\"Replicate\", model_id=model_id)"
    ]
   },
   {
@@ -162,9 +162,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "replicate_response = granite_via_replicate.invoke(prompt)\n",
+    "response = model.invoke(prompt)\n",
     "\n",
-    "print(f\"Granite response from Replicate: {replicate_response}\")"
+    "print(f\"Granite response from Replicate: {response}\")"
    ]
   },
   {
@@ -196,21 +196,21 @@
    "id": "4e92ff5c-510f-4ed2-9688-6831b6b91a4d",
    "metadata": {},
    "source": [
-    "### Choose a model"
+    "### Choose a Model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "937957fd-36c0-4c0f-b91d-afd8de1447ef",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_id = \"granite-code:3b\"\n",
-    "# model_id = \"granite-code:8b\"\n",
+    "# model_id = \"granite-code:3b\"\n",
+    "model_id = \"granite-code:8b\"\n",
     "# model_id = \"granite-code:20b\"\n",
     "\n",
-    "granite_via_ollama = find_langchain_model(platform=\"ollama\", model_id=model_id)"
+    "model = find_langchain_model(platform=\"ollama\", model_id=model_id)"
    ]
   },
   {
@@ -228,15 +228,124 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ollama_response = granite_via_ollama.invoke(prompt)\n",
+    "response = model.invoke(prompt)\n",
     "\n",
-    "print(f\"Granite response from Ollama: {ollama_response}\")"
+    "print(f\"Granite response from Ollama: {response}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7828a665",
+   "metadata": {},
+   "source": [
+    "## Remote Model using IBM WatsonX"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d18460e3",
+   "metadata": {},
+   "source": [
+    "### Establish a WatsonX Account\n",
+    "\n",
+    "To use this remote option, create an account on [WatsonX](https://www.ibm.com/watsonx)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "556e261e",
+   "metadata": {},
+   "source": [
+    "### Provide the Environment Variables\n",
+    "\n",
+    "There are three ways to provide the environment variables required by `find_langchain_model()` below.  In order of precedence:\n",
+    "\n",
+    "1. Directly as an environment variable in the python environment where the jupyter notebook is running.\n",
+    "2. As a Google Colab secret, if you are running the notebook in Colab.\n",
+    "3. Supplied by the user in a prompt during execution of the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c07c7c9a",
+   "metadata": {},
+   "source": [
+    "### Provide your API Key\n",
+    "\n",
+    "Obtain your `WATSONX_APIKEY` by generating a [Platform API Key](https://www.ibm.com/docs/en/watsonx/watsonxdata/1.0.x?topic=started-generating-api-keys) on the watsonx.data web client.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73ddc7d6",
+   "metadata": {},
+   "source": [
+    "### Provide your Project Id\n",
+    "\n",
+    "Get your `WATSONX_PROJECT_ID` from the [WatsonX](https://www.ibm.com/watsonx) web client by following [these instructions](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-project-id.html?context=wx)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b76cdf0",
+   "metadata": {},
+   "source": [
+    "### Provide your Base WatsonX URL\n",
+    "\n",
+    "Get your `WATSONX_URL` by viewing the details for the service instance from the Cloud Pak for Data web client, as described in [these watsonx.ai setup instructions](https://ibm.github.io/watsonx-ai-python-sdk/setup_cpd.html).\n",
+    "\n",
+    "As an example, your `WATSONX_URL` may be `https://us-south.ml.cloud.ibm.com` for the Dallas zone."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35dbaee4",
+   "metadata": {},
+   "source": [
+    "### Choose a Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "86a7ef73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# model_id = \"ibm/granite-3b-code-instruct\"\n",
+    "model_id = \"ibm/granite-8b-code-instruct\"\n",
+    "# model_id = \"ibm/granite-20b-code-instruct\"\n",
+    "# model_id = \"ibm/granite-34b-code-instruct\"\n",
+    "\n",
+    "import os\n",
+    "model = find_langchain_model(platform=\"watsonx\", model_id=model_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7f4db5e",
+   "metadata": {},
+   "source": [
+    "### Perform Inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddfdb7ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = model.invoke(prompt)\n",
+    "\n",
+    "print(f\"Granite response from WatsonX: {response}\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -250,7 +359,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
[#124](https://github.com/ibm-granite-community/pm/issues/124) Add WatsonX as a Provider:
- Add WatsonX example to Getting Started recipe alongside Replicate and Ollama
- Normalize naming of `model` and `response` to indicate this is where the setup pathways join. Ok?

NOTE: this PR depends on the corresponding [Utils PR](https://github.com/ibm-granite-community/utils/pull/6).
