### PR TITLE
Remove ToC entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@ If you are interested in joining our community, please [join us on Discord](http
 
 ## Recipes
 
-### Large Language Model Inference
-
-1. [Use Granite Code Hosted on Replicate](recipes/Getting_Started_with_Granite_Code.ipynb)
-   <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-code-cookbook/blob/main/recipes/Getting_Started_with_Granite_Code.ipynb">
-   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-   </a>
-
 ### IDE Assistants
 
 1. [Coding Assistant in VSCode](recipes/Coding_Assistant_in_VSCode/Coding_Assistant_in_VSCode.ipynb)
@@ -37,14 +30,6 @@ If you are interested in joining our community, please [join us on Discord](http
    </a>
 1. [Automated Code Documentation](recipes/Automated_Documentation/Automated_Documentation.ipynb)
    <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-code-cookbook/blob/main/recipes/Automated_Documentation/Automated_Documentation.ipynb">
-   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-   </a>
-
-
-### Guard Rails
-
-1. [Hate, Abuse, and Profanity (HAP) Scoring](recipes/Guard-Rails/HAP.ipynb)
-   <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/granite-code-cookbook/blob/main/recipes/Guard-Rails/HAP.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
 


### PR DESCRIPTION
Removing ToC entries for Getting Started and HAP recipes, which are now in the Snack Cookbook.

Leaving the implementing .ipynb files because there are still references to them.