### PR TITLE
Code - Install Utils instead of Kitchen

### DIFF
--- a/recipes/Getting_Started_with_Granite_Code.ipynb
+++ b/recipes/Getting_Started_with_Granite_Code.ipynb
@@ -35,7 +35,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    replicate"
    ]
   },
   {

--- a/recipes/Text_to_SQL/Text_to_SQL.ipynb
+++ b/recipes/Text_to_SQL/Text_to_SQL.ipynb
@@ -37,7 +37,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    replicate"
    ]
   },
   {

--- a/recipes/Text_to_Shell/Text_to_Shell.ipynb
+++ b/recipes/Text_to_Shell/Text_to_Shell.ipynb
@@ -36,7 +36,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    replicate\n"
    ]
   },
   {

--- a/recipes/Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb
+++ b/recipes/Text_to_Shell_Exec/Text_to_Shell_Exec.ipynb
@@ -41,7 +41,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/ibm-granite-community/granite-kitchen"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    replicate"
    ]
   },
   {

--- a/recipes/Unit_Tests_Generation/Unit_Tests_Generation.ipynb
+++ b/recipes/Unit_Tests_Generation/Unit_Tests_Generation.ipynb
@@ -45,7 +45,9 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "### Install the required Langchain and replicate packages"
+    "### Install the required Langchain and Replicate packages\n",
+    "\n",
+    "Include a granite-community package with some simple utility functions."
    ]
   },
   {
@@ -55,35 +57,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install langchain_community replicate"
+    "!pip install git+https://github.com/ibm-granite-community/utils \\\n",
+    "    \"langchain_community<0.3.0\" \\\n",
+    "    replicate"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4",
-   "metadata": {},
-   "source": [
-    "### Install the Granite `utils` package\n",
-    "\n",
-    "This package is a thin shim with various functions that are required for notebooks.\n",
-    "\n",
-    "To see the implementation of its functions, see the [utils repo](https://github.com/ibm-granite-community/utils/)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/ibm-granite-community/utils"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Define a System Prompt\n",
@@ -103,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Remote Model using Replicate\n",
@@ -130,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "8",
    "metadata": {},
    "source": [
     "Now, we define the model to use and a dictional of parameters to pass to the `Replicate` constructor."
@@ -139,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +150,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "12",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Perform Inference\n",
@@ -181,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "12",
    "metadata": {},
    "source": [
     "Here are some steps you can use to try running the generated test code:\n",
@@ -238,7 +220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "13",
    "metadata": {},
    "source": [
     "#### Second Example: Generate Tests for Multiple Functions\n",
@@ -249,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +280,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "15",
    "metadata": {},
    "source": [
     "#### Third Example: Generate Tests for \"Middleware\" Code\n",
@@ -309,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "17",
    "metadata": {},
    "source": [
     "#### Fourth Example: More Use of \"Test Doubles\"\n",
@@ -378,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +452,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "19",
    "metadata": {},
    "source": [
     "#### Fifth Example: Test External API Calls"
@@ -479,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "source": [
     "#### Sixth Example: Same as the Fifth Example, but Omit Requesting a Specific Test Library"
@@ -512,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
[#152](https://github.com/ibm-granite-community/pm/issues/152)
- Replace granite-kitchen with utils install in recipes.

### PR Checklist

- [ ] **Commits signed**: All commits must be GPG or SSH signed.
- [ ] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
- [ ] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [ ] **Automated testing**: Add the recipe to the automated tests.
- [ ] **Test in Google Colab**:
    - [ ] Test that it works in Google Colab (Python 3.10.12).
    - [ ] Colab has its own package set and Python version, so ensure compatibility.
- [ ] **Test locally**:
    - [ ] Ensure the code works in a fresh Python virtual environment (venv).
- [ ] **Flexible LLM platform support**:
    - [ ] The platform should be easily switchable. Use LangChain for now.
    - [ ] Include `!pip install git+https://github.com/ibm-granite-community/granite-kitchen` in the instructions.
- [ ] **Example data**: Follow the example data guidance.
- [ ] **README.md updates**:
    - [ ] Add a link to the recipe in the Table of Contents (ToC).
    - [ ] Include a Colab button after that link.
