### PR TITLE
Replace use of set_env_var with get_env_var

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # Run `pre-commit install` to activate pre-commit hooks
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.8.1
     hooks:
       - id: nbstripout
         args: [

--- a/recipes/Auto_Documentation/Auto_Documentation.ipynb
+++ b/recipes/Auto_Documentation/Auto_Documentation.ipynb
@@ -59,7 +59,8 @@
     "\n",
     "To use the Replicate API, we need to authenticate our requests. This is done using an API token.\n",
     "\n",
-    "For security reasons, it's best to store this token as an environment variable rather than hardcoding it into our script. If we are using Google Colab, the `set_env_var` function will use the `userdata` feature to retrieve the token.\n",
+    "For security reasons, it's best to store this token as an environment variable rather than hardcoding it into our script. If we are using Google Colab, the `get_env_var` function will use the `userdata` feature to retrieve the token\n",
+    "and set it in the environment variable.\n",
     "\n",
     "Remember to never share your API tokens publicly or commit them to version control systems."
    ]
@@ -72,9 +73,9 @@
    },
    "outputs": [],
    "source": [
-    "from ibm_granite_community.notebook_utils import set_env_var\n",
+    "from ibm_granite_community.notebook_utils import get_env_var\n",
     "\n",
-    "set_env_var(\"REPLICATE_API_TOKEN\", None)"
+    "get_env_var(\"REPLICATE_API_TOKEN\")"
    ]
   },
   {

--- a/recipes/Unit_Tests_Generation/Unit_Tests_Generation.ipynb
+++ b/recipes/Unit_Tests_Generation/Unit_Tests_Generation.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ibm_granite_community.notebook_utils import set_env_var, get_env_var"
+    "from ibm_granite_community.notebook_utils import get_env_var"
    ]
   },
   {
@@ -527,11 +527,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -541,8 +536,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## PR Checklist

### Notebook requirements

- [x] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [x] **Standard access to secrets and variables** Include `!pip install git+https://github.com/ibm-granite-community/utils` in the first code cell in order to make `get_env_var` available to accessing secrets and variables in the recipe.

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
